### PR TITLE
Convert roxygen2 comments to markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,3 +26,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 URL: https://imperialchepi.github.io/healthgpsrvis/
+Roxygen: list(markdown = TRUE)

--- a/R/data-process.R
+++ b/R/data-process.R
@@ -3,7 +3,7 @@
 #' This file contains a set of functions designed to work together for processing the data.
 #' Below is a description of how to use these functions in sequence.
 #'
-#' Step-by-Step Usage:
+#' ## Step-by-Step Usage:
 #'
 #' 1. **Read the data**: This function reads the data from the location specified.
 #'    ```{r, eval=FALSE}

--- a/R/setup-graphics.R
+++ b/R/setup-graphics.R
@@ -38,16 +38,16 @@ set_graphics <- function(width, height){
 #' @details
 #' The `hgps_theme` function modifies the following elements of the classic theme:
 #' \itemize{
-#'   \item \code{plot.title}: Sets the font size of the plot title (default is 15).
-#'   \item \code{axis.title.x}: Sets the font size of the x-axis title (default is 10).
-#'   \item \code{axis.title.y}: Sets the font size of the y-axis title (default is 10).
-#'   \item \code{axis.text.x}: Sets the font size of the x-axis text (default is 8).
-#'   \item \code{axis.text.y}: Sets the font size of the y-axis text (default is 8).
-#'   \item \code{legend.text}: Sets the font size of the legend text (default is 8).
-#'   \item \code{legend.title}: Removes the legend title.
-#'   \item \code{panel.grid.major.x}: Adds major grid lines on the x-axis.
-#'   \item \code{legend.key}: Sets the legend key background (default is "transparent").
-#'   \item \code{legend.position}: Positions the legend (default coordinates are (0.8, 0.9)).
+#'   \item `plot.title`: Sets the font size of the plot title (default is 15).
+#'   \item `axis.title.x`: Sets the font size of the x-axis title (default is 10).
+#'   \item `axis.title.y`: Sets the font size of the y-axis title (default is 10).
+#'   \item `axis.text.x`: Sets the font size of the x-axis text (default is 8).
+#'   \item `axis.text.y`: Sets the font size of the y-axis text (default is 8).
+#'   \item `legend.text`: Sets the font size of the legend text (default is 8).
+#'   \item `legend.title`: Removes the legend title.
+#'   \item `panel.grid.major.x`: Adds major grid lines on the x-axis.
+#'   \item `legend.key`: Sets the legend key background (default is "transparent").
+#'   \item `legend.position`: Positions the legend (default coordinates are (0.8, 0.9)).
 #' }
 #'
 #' @examples

--- a/man/DataProcessing.Rd
+++ b/man/DataProcessing.Rd
@@ -8,46 +8,54 @@ This file contains a set of functions designed to work together for processing t
 Below is a description of how to use these functions in sequence.
 }
 \details{
-Step-by-Step Usage:
+\subsection{Step-by-Step Usage:}{
+\enumerate{
+\item \strong{Read the data}: This function reads the data from the location specified.
+}
 
-1. **Read the data**: This function reads the data from the location specified.
-   ```{r, eval=FALSE}
-   data <-  readRDS("data.rds")
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data <-  readRDS("data.rds")
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_mean}}: Calculates weighted mean values for various metrics over years.
+}
 
-2. **`gen_data_mean`**: Calculates weighted mean values for various metrics over years.
-   ```{r, eval=FALSE}
-   data_weighted <- gen_data_mean(data)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_weighted <- gen_data_mean(data)
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_weighted_rf}}: Calculates the differences between intervention and baseline values for risk factors.
+}
 
-3. **`gen_data_weighted_rf`**: Calculates the differences between intervention and baseline values for risk factors.
-   ```{r, eval=FALSE}
-   data_weighted_rf_wide_collapse <- gen_data_weighted_rf(data_weighted)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_weighted_rf_wide_collapse <- gen_data_weighted_rf(data_weighted)
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_weighted_ds}}: Calculates the differences between intervention and baseline values for incidences.
+}
 
-4. **`gen_data_weighted_ds`**: Calculates the differences between intervention and baseline values for incidences.
-   ```{r, eval=FALSE}
-   data_weighted_ds_wide_collapse <- gen_data_weighted_ds(data_weighted)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_weighted_ds_wide_collapse <- gen_data_weighted_ds(data_weighted)
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_weighted_burden}}: Calculates the differences between intervention and baseline values for burden of disease.
+}
 
-5. **`gen_data_weighted_burden`**: Calculates the differences between intervention and baseline values for burden of disease.
-   ```{r, eval=FALSE}
-   data_weighted_burden_wide_collapse <- gen_data_weighted_burden(data_weighted)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_weighted_burden_wide_collapse <- gen_data_weighted_burden(data_weighted)
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_weighted_burden_spline}}: Performs data smoothing for burden of disease, when necessary. For instance, with only a few simulations, there can be positive values in difference in burden of disease.
+}
 
-6. **`gen_data_weighted_burden_spline`**: Performs data smoothing for burden of disease, when necessary. For instance, with only a few simulations, there can be positive values in difference in burden of disease.
-   ```{r, eval=FALSE}
-   data_weighted_burden_spline <- gen_data_weighted_burden_spline(data_weighted_burden_wide_collapse)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_weighted_burden_spline <- gen_data_weighted_burden_spline(data_weighted_burden_wide_collapse)
+}\if{html}{\out{</div>}}
+\enumerate{
+\item \strong{\code{gen_data_le}}: Calculates life expectancy for various age and groups.
+}
 
-7. **`gen_data_le`**: Calculates life expectancy for various age and groups.
-   ```{r, eval=FALSE}
-   data_ple_wide <- gen_data_le(data_weighted)
-   ```
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_ple_wide <- gen_data_le(data_weighted)
+}\if{html}{\out{</div>}}
+}
 
-## Examples
-```r
-# Example of using all functions together
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Example of using all functions together
 data <- readRDS("data.rds")
 data_weighted <- gen_data_mean(data)
 data_weighted_rf_wide_collapse <- gen_data_weighted_rf(data_weighted)
@@ -55,5 +63,6 @@ data_weighted_ds_wide_collapse <- gen_data_weighted_ds(data_weighted)
 data_weighted_burden_wide_collapse <- gen_data_weighted_burden(data_weighted)
 data_weighted_burden_spline <- gen_data_weighted_burden_spline(data_weighted_burden_wide_collapse)
 data_ple_wide <- gen_data_le(data_weighted)
-```
+}\if{html}{\out{</div>}}
+}
 }

--- a/man/hgps_theme.Rd
+++ b/man/hgps_theme.Rd
@@ -12,21 +12,21 @@ axis text, legend text, legend title, major grid lines, legend key background, a
 }
 \description{
 This function creates a customised theme for ggplot2 plots. It modifies various
-elements of the default `theme_classic()` to provide a specific style.
+elements of the default \code{theme_classic()} to provide a specific style.
 }
 \details{
-The `hgps_theme` function modifies the following elements of the classic theme:
+The \code{hgps_theme} function modifies the following elements of the classic theme:
 \itemize{
-  \item \code{plot.title}: Sets the font size of the plot title (default is 15).
-  \item \code{axis.title.x}: Sets the font size of the x-axis title (default is 10).
-  \item \code{axis.title.y}: Sets the font size of the y-axis title (default is 10).
-  \item \code{axis.text.x}: Sets the font size of the x-axis text (default is 8).
-  \item \code{axis.text.y}: Sets the font size of the y-axis text (default is 8).
-  \item \code{legend.text}: Sets the font size of the legend text (default is 8).
-  \item \code{legend.title}: Removes the legend title.
-  \item \code{panel.grid.major.x}: Adds major grid lines on the x-axis.
-  \item \code{legend.key}: Sets the legend key background (default is "transparent").
-  \item \code{legend.position}: Positions the legend (default coordinates are (0.8, 0.9)).
+\item \code{plot.title}: Sets the font size of the plot title (default is 15).
+\item \code{axis.title.x}: Sets the font size of the x-axis title (default is 10).
+\item \code{axis.title.y}: Sets the font size of the y-axis title (default is 10).
+\item \code{axis.text.x}: Sets the font size of the x-axis text (default is 8).
+\item \code{axis.text.y}: Sets the font size of the y-axis text (default is 8).
+\item \code{legend.text}: Sets the font size of the legend text (default is 8).
+\item \code{legend.title}: Removes the legend title.
+\item \code{panel.grid.major.x}: Adds major grid lines on the x-axis.
+\item \code{legend.key}: Sets the legend key background (default is "transparent").
+\item \code{legend.position}: Positions the legend (default coordinates are (0.8, 0.9)).
 }
 }
 \examples{

--- a/man/set_graphics.Rd
+++ b/man/set_graphics.Rd
@@ -16,10 +16,10 @@ This function closes all existing graphical devices and opens a new one
 with specified width and height dimensions.
 }
 \details{
-The `set_graphics` function first closes all open graphical devices using `graphics.off()`.
-It then opens a new graphical device with the given dimensions using `dev.new()`.
-The `unit` parameter is set to "cm" to use centimeters for the dimensions,
-and `noRStudioGD` is set to `TRUE` to avoid using RStudio's graphical device.
+The \code{set_graphics} function first closes all open graphical devices using \code{graphics.off()}.
+It then opens a new graphical device with the given dimensions using \code{dev.new()}.
+The \code{unit} parameter is set to "cm" to use centimeters for the dimensions,
+and \code{noRStudioGD} is set to \code{TRUE} to avoid using RStudio's graphical device.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Turn on Markdown support for the `healthgpsrvis` package :

1. Since we’re updating an existing package, running `usethis::use_roxygen_md()` will modify the `DESCRIPTION` (to include `Roxygen: [list](https://rdrr.io/r/base/list.html)(markdown = TRUE)`) and prompt us to use the [roxygen2md](https://roxygen2md.r-lib.org/) package to convert the existing docs.
2. Once the package `roxygen2md` is downloaded, run `roxygen2md::roxygen2md()` to convert existing `Rd` comments to markdown.
3. Run `devtools::document()` when you're done.
4. Finally run `devtools::check()`.