### PR TITLE
Add specific path to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -45,8 +45,10 @@ This is an example to create the weighted data using the package:
 ```{r example}
 library(healthgpsrvis)
 
-# Get the path to the .rds file
+# Get the path to the .rds file included in the testdata folder
 filepath <- testthat::test_path("testdata", "data_ps3_reformulation")
+#filepath <- "path/to/data.rds" # Get the path to the .rds file included in any other local folder
+
 
 # Read the .rds file
 data <- readRDS(filepath)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ This is an example to create the weighted data using the package:
 ``` r
 library(healthgpsrvis)
 
-# Get the path to the .rds file
+# Get the path to the .rds file included in the testdata folder
 filepath <- testthat::test_path("testdata", "data_ps3_reformulation")
+#filepath <- "path/to/data.rds" # Get the path to the .rds file included in any other local folder
+
 
 # Read the .rds file
 data <- readRDS(filepath)


### PR DESCRIPTION
This pull request includes updates to the documentation in the `README` to provide additional context on how to get a specific path to the `.rds` file.
